### PR TITLE
Admin Orders-shipments

### DIFF
--- a/app/controllers/spree/admin/shipments_controller.rb
+++ b/app/controllers/spree/admin/shipments_controller.rb
@@ -1,0 +1,16 @@
+module Spree
+  class Admin::ShipmentsController < Spree::Admin::BaseController
+
+    def index
+      @order = Order.find_by_number!(params[:order_id], :include => :shipments)
+      authorize! :manage, @order
+      @shipments = @order.shipments
+    end
+
+    def edit
+      @order = Order.find_by_number!(params[:order_id], :include => :shipments)
+      @shipment = @order.shipments.find_by_number!(params[:id])
+    end
+    
+  end
+end

--- a/app/overrides/add_shipments_tab.rb
+++ b/app/overrides/add_shipments_tab.rb
@@ -1,0 +1,5 @@
+Deface::Override.new(:virtual_path => "spree/admin/shared/_order_tabs",
+                     :name => "add_shipments_tab",
+                     :insert_bottom => "[data-hook='admin_order_tabs']",
+                     :partial => "spree/admin/shared/shipments_tab") 
+

--- a/app/views/spree/admin/shared/_shipments_tab.html.erb
+++ b/app/views/spree/admin/shared/_shipments_tab.html.erb
@@ -1,0 +1,7 @@
+<% if can? :index, @order.shipments %>
+  <% if @order.completed? %>
+    <li<%== ' class="active"' if current == 'Shipments' %>>
+      <%= link_to_with_icon 'icon-share-alt', Spree.t(:shipments), admin_order_shipments_path(@order) %>
+    </li>
+  <% end %>
+<% end %>      

--- a/app/views/spree/admin/shipments/_list.html.erb
+++ b/app/views/spree/admin/shipments/_list.html.erb
@@ -1,0 +1,20 @@
+<table class="index">
+  <thead>
+    <tr data-hook="shipments_header">
+      <th><%= Spree.t(:number) %></th>
+      <th><%= Spree.t(:shipping_method) %> </th>
+      <th><%= Spree.t(:state) %> </th>
+      <th><%= Spree.t(:stock_location) %></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @shipments.each do |shipment| %>
+      <td><%= link_to shipment.number, edit_admin_order_shipment_path(@order, shipment) %></td>
+      <td><%= shipment.shipping_method.name.capitalize  %></td>
+      <td><span class="state <%= shipment.state %>"><%= shipment.state %></span> </td>
+      <td><%= shipment.stock_location.name.capitalize %> </td>
+    <% end  %>
+  </tbody>
+
+</table>

--- a/app/views/spree/admin/shipments/edit.html.erb
+++ b/app/views/spree/admin/shipments/edit.html.erb
@@ -1,0 +1,13 @@
+<%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Shipments' } %>
+
+<% content_for :page_title do %>
+  <i class="icon-arrow-right"></i>
+  <%= Spree.t(:shipment) %> #<%= @shipment.number %>  
+<% end %>
+
+<% content_for :page_actions do %>
+  <li><%= button_link_to Spree.t(:back_to_shipments_list), spree.admin_order_shipments_url(@order), :icon => 'icon-arrow-left' %></li>
+<% end %>
+
+<%= link_to "Post To Unifaun", "", :class => "button" %>
+<%= link_to "Get Unifaun Status", "", :class => "button" %>

--- a/app/views/spree/admin/shipments/index.html.erb
+++ b/app/views/spree/admin/shipments/index.html.erb
@@ -1,0 +1,15 @@
+<%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Shipments' } %>
+
+<% content_for :page_actions do %>  
+  <li><%= button_link_to Spree.t(:back_to_order_details), edit_admin_order_path(@order), :icon => 'icon-arrow-left' %></li>
+<% end %>
+
+<% content_for :page_title do %>
+  <i class="icon-arrow-right"></i> <%= Spree.t(:shipments) %>
+<% end %>
+
+<% if @shipments.any? %>
+  <%= render :partial => 'list', :locals => { :shipments => @shipments } %>
+<% else %>
+  <div class="alpha twelve columns no-objects-found"><%= Spree.t(:order_has_no_shipments) %></div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,8 @@ Spree::Core::Engine.routes.append do
     #   get :related, on: :member
     #   resources :relations
     # end
+    resources :order do 
+      resources :shipments
+    end
   end
 end

--- a/spec/controllers/spree/admin/shipments_controller_spec.rb
+++ b/spec/controllers/spree/admin/shipments_controller_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe Spree::Admin::ShipmentsController do
+
+  let(:order){ create(:order) }
+  let(:user){ order.user }
+
+  context "#index" do
+    stub_authorization!
+    
+    before do
+      controller.stub :spree_current_user => user
+    end
+
+    it "should set shipments" do
+      shipments = [create(:shipment, order: order), create(:shipment, order: order)]
+      spree_get :index, order_id: order.number
+      assigns[:shipments].should eq(shipments) 
+    end
+  end
+
+  context "#edit" do
+  end
+end

--- a/spec/requests/admin/orders/order_details_spec.rb
+++ b/spec/requests/admin/orders/order_details_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe "Order Details" do
+  let(:order) { create(:order, state: 'complete', completed_at: "2011-02-01 12:36:15", number: "R100") }
+
+  context 'as Admin' do
+    stub_authorization!
+
+    before { visit spree.edit_admin_order_path(order) }
+
+    context "edit order page" do
+      it "should have a link to shipments-page" do
+        click_link :Shipments
+        page.should have_content("Shipments")    
+      end
+    end
+  end 
+end

--- a/spec/requests/admin/orders/order_shipments_spec.rb
+++ b/spec/requests/admin/orders/order_shipments_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe "Order shipments" do
+  let(:shipment){ create(:shipment, number: 'H100')}
+  let(:order){ shipment.order }
+
+  context '[as Admin]' do
+    stub_authorization!
+
+    context "index page" do
+      it "should say 'Order has no shipments' when order has no shipments" do
+        order.shipments.clear
+        visit spree.admin_order_shipments_path(order)
+        page.should have_content "Order Has No Shipments"
+      end
+      
+      it "should list existing shipments" do
+        visit spree.admin_order_shipments_path(order)
+        page.should have_content "H100"
+      end
+    end
+
+    context "edit page" do
+      it "should have a button for posting to Unifaun" do
+        visit spree.edit_admin_order_shipment_path(order, shipment)
+        page.should have_link "Post To Unifaun"
+      end
+
+      it "should have a button for getting status from Unifaun" do
+        visit spree.edit_admin_order_shipment_path(order, shipment)
+        page.should have_link "Get Unifaun Status"
+      end
+    end
+  end  
+end


### PR DESCRIPTION
## Admin side implementation for Unifaun integration
### How it looks:
#### Order-details page

![order-details](http://i.imgur.com/trEuZLc.png)
#### Order-shipments page

![order-shipments](http://i.imgur.com/3kVPCIh.png)
#### Order-shipment-edit page

![order-shipment-edit](http://i.imgur.com/TjyoW50.png)

---
### Not implemented in this:

The `Post to Unifaun` and `Get status from Unifaun` buttons functionality as they depends on the backend xml-integration .
### Test coverage right now:

97 / 102 LOC (95.1%)
### Commit message
- Adds a 'Shipments' link to the order-details page in the sidebar tab
- Introduces an /admin/orders/:order_id/shipments page, where all shipments associated with the order are listed
- Introduces an /admin/order/:order_id/shipments/:id/edit page, for details of a particular shipment
- The order-shipment-edit page contains the buttons for 'Post to Unifaun' and 'Get status from Unifaun'
- The buttons are not functional right now.
